### PR TITLE
Add rpcbind to repo README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ server=1
 rpcuser=my_username
 rpcpassword=my_password
 rpcallowip=127.0.0.1
+rpcbind=0.0.0.0
 ```
 On *nix OS's this file is located at `~/.meowcoin` by default. On windows, this file is located at `%appdata%\Meowcoin`.
 


### PR DESCRIPTION
Starting with Meowcoin v1.0.5 the core will require the rpcbind=0.0.0.0 for the proxy to work